### PR TITLE
Rule sets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aoc-parse"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2021"
 description = "A little library for parsing your Advent of Code puzzle input"
 repository = "https://github.com/jorendorff/aoc-parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["aoc", "parse", "puzzle", "parser", "advent"]
 [dependencies]
 lazy_static = "1.4"
 num-bigint = "0.4"
+num-traits = "0.2"
 regex = "1"
 thiserror = "1"
 tuple_utils = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ tuple_utils = "0.4"
 [dev-dependencies]
 anyhow = "1.0"
 aoc-runner-derive = "0.3.0"
+serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ lines({         // matches lines made up of the characters < = >
 
 Here are the pieces that you can use in a pattern:
 
-*   `i8`, `i16`, `i32`, `i64`, `i128`, `isize` - These match an integer,
+*   `i8`, `i16`, `i32`, `i64`, `i128`, `isize`, `big_int` - These match an integer,
     written out using decimal digits, with an optional `+` or `-` sign
     at the start, like `0` or `-11474`.
 
@@ -78,13 +78,15 @@ Here are the pieces that you can use in a pattern:
     type you chose. For example, `parser!(i8).parse("1000")` is an error.
     (It matches the string, but fails during the "convert" phase.)
 
-*   `u8`, `u16`, `u32`, `u64`, `u128`, `usize` - The same, but without
-    the sign.
+    `big_int` parses a [`num_bigint::BigInt`].
 
-*   `i8_bin`, `i16_bin`, `i32_bin`, `i64_bin`, `i128_bin`, `isize_bin`,
-    `u8_bin`, `u16_bin`, `u32_bin`, `u64_bin`, `u128_bin`, `usize_bin`,
-    `i8_hex`, `i16_hex`, `i32_hex`, `i64_hex`, `i128_hex`, `isize_hex`,
-    `u8_hex`, `u16_hex`, `u32_hex`, `u64_hex`, `u128_hex`, `usize_hex` -
+*   `u8`, `u16`, `u32`, `u64`, `u128`, `usize`, `big_uint` - The same, but
+    without the sign.
+
+*   `i8_bin`, `i16_bin`, `i32_bin`, `i64_bin`, `i128_bin`, `isize_bin`, `big_int_bin`,
+    `u8_bin`, `u16_bin`, `u32_bin`, `u64_bin`, `u128_bin`, `usize_bin`, `big_uint_bin`,
+    `i8_hex`, `i16_hex`, `i32_hex`, `i64_hex`, `i128_hex`, `isize_hex`, `big_int_hex`,
+    `u8_hex`, `u16_hex`, `u32_hex`, `u64_hex`, `u128_hex`, `usize_hex`, `big_uint_hex` -
     Match an integer in base 2 or base 16. The `_hex` parsers allow both
     uppercase and lowercase digits `A`-`F`.
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,45 @@ Alternatives:
     }));
     ```
 
+Rule sets:
+
+*   <code>rule <var>name1</var>: <var>type1</var> = <var>pattern1</var>;</code> -
+    Introduce a "rule", a named subparser.
+
+    This supports parsing text with nesting brackets.
+
+    ```
+    # use aoc_parse::{parser, prelude::*};
+    enum Formation {
+        Elf(char),
+        Stack(Vec<Formation>),
+    }
+
+    let p = parser!(
+        // First rule: A "formation" has return type Formation and is either
+        // a letter or a stack.
+        rule formation: Formation = {
+            s:alpha => Formation::Elf(s),
+            v:stack => Formation::Stack(v),
+        };
+
+        // Second rule: A "stack" is one or more formations, wrapped in
+        // matching parentheses.
+        rule stack: Vec<Formation> = '(' v:formation+ ')' => v;
+
+        // After all rules, the pattern that .parse() will actually match.
+        lines(formation+)
+    );
+
+    assert!(p.parse("px(fo(i)(RR(c)))j(Q)zww\n").is_ok());
+    assert!(p.parse("x)fo\n").is_err());
+    ```
+
+    Ordinarily `let` suffices for parsers used by other parsers; but `rule`
+    is needed for parsers that refer to themselves or to each other,
+    cyclically, like `formation` and `stack` above. Rust's `let` doesn't
+    support that.
+
 Lines and sections:
 
 *   <code>line(<var>pattern</var>)</code> - Matches a single line of text that

--- a/src/context.rs
+++ b/src/context.rs
@@ -142,12 +142,23 @@ impl<'parse> ParseContext<'parse> {
         self.report(ParseError::new_extra(self.source(), location))
     }
 
-    pub(crate) fn register_rule_set(&mut self, rule_set_id: usize, rule_parsers: &'parse [Box<dyn Any>]) {
+    pub(crate) fn register_rule_set(
+        &mut self,
+        rule_set_id: usize,
+        rule_parsers: &'parse [Box<dyn Any>],
+    ) {
         self.rule_sets.insert(rule_set_id, rule_parsers);
     }
 
-    pub(crate) fn fetch_parser_for_rule(&self, rule_set_id: usize, index: usize) -> &'parse dyn Any {
-        let rule_parsers: &'parse [Box<dyn Any>] = self.rule_sets.get(&rule_set_id).expect("internal error: rule set not registered");
+    pub(crate) fn fetch_parser_for_rule(
+        &self,
+        rule_set_id: usize,
+        index: usize,
+    ) -> &'parse dyn Any {
+        let rule_parsers: &'parse [Box<dyn Any>] = self
+            .rule_sets
+            .get(&rule_set_id)
+            .expect("internal error: rule set not registered");
         &*rule_parsers[index]
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,6 +270,45 @@
 //!     }));
 //!     ```
 //!
+//! Rule sets:
+//!
+//! *   <code>rule <var>name1</var>: <var>type1</var> = <var>pattern1</var>;</code> -
+//!     Introduce a "rule", a named subparser.
+//!
+//!     This supports parsing text with nesting brackets.
+//!
+//!     ```
+//!     # use aoc_parse::{parser, prelude::*};
+//!     enum Formation {
+//!         Elf(char),
+//!         Stack(Vec<Formation>),
+//!     }
+//!
+//!     let p = parser!(
+//!         // First rule: A "formation" has return type Formation and is either
+//!         // a letter or a stack.
+//!         rule formation: Formation = {
+//!             s:alpha => Formation::Elf(s),
+//!             v:stack => Formation::Stack(v),
+//!         };
+//!
+//!         // Second rule: A "stack" is one or more formations, wrapped in
+//!         // matching parentheses.
+//!         rule stack: Vec<Formation> = '(' v:formation+ ')' => v;
+//!
+//!         // After all rules, the pattern that .parse() will actually match.
+//!         lines(formation+)
+//!     );
+//!
+//!     assert!(p.parse("px(fo(i)(RR(c)))j(Q)zww\n").is_ok());
+//!     assert!(p.parse("x)fo\n").is_err());
+//!     ```
+//!
+//!     Ordinarily `let` suffices for parsers used by other parsers; but `rule`
+//!     is needed for parsers that refer to themselves or to each other,
+//!     cyclically, like `formation` and `stack` above. Rust's `let` doesn't
+//!     support that.
+//!
 //! Lines and sections:
 //!
 //! *   <code>line(<var>pattern</var>)</code> - Matches a single line of text that

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@
 //!
 //! Here are the pieces that you can use in a pattern:
 //!
-//! *   `i8`, `i16`, `i32`, `i64`, `i128`, `isize` - These match an integer,
+//! *   `i8`, `i16`, `i32`, `i64`, `i128`, `isize`, `big_int` - These match an integer,
 //!     written out using decimal digits, with an optional `+` or `-` sign
 //!     at the start, like `0` or `-11474`.
 //!
@@ -83,13 +83,15 @@
 //!     type you chose. For example, `parser!(i8).parse("1000")` is an error.
 //!     (It matches the string, but fails during the "convert" phase.)
 //!
-//! *   `u8`, `u16`, `u32`, `u64`, `u128`, `usize` - The same, but without
-//!     the sign.
+//!     `big_int` parses a [`num_bigint::BigInt`].
 //!
-//! *   `i8_bin`, `i16_bin`, `i32_bin`, `i64_bin`, `i128_bin`, `isize_bin`,
-//!     `u8_bin`, `u16_bin`, `u32_bin`, `u64_bin`, `u128_bin`, `usize_bin`,
-//!     `i8_hex`, `i16_hex`, `i32_hex`, `i64_hex`, `i128_hex`, `isize_hex`,
-//!     `u8_hex`, `u16_hex`, `u32_hex`, `u64_hex`, `u128_hex`, `usize_hex` -
+//! *   `u8`, `u16`, `u32`, `u64`, `u128`, `usize`, `big_uint` - The same, but
+//!     without the sign.
+//!
+//! *   `i8_bin`, `i16_bin`, `i32_bin`, `i64_bin`, `i128_bin`, `isize_bin`, `big_int_bin`,
+//!     `u8_bin`, `u16_bin`, `u32_bin`, `u64_bin`, `u128_bin`, `usize_bin`, `big_uint_bin`,
+//!     `i8_hex`, `i16_hex`, `i32_hex`, `i64_hex`, `i128_hex`, `isize_hex`, `big_int_hex`,
+//!     `u8_hex`, `u16_hex`, `u32_hex`, `u64_hex`, `u128_hex`, `usize_hex`, `big_uint_hex` -
 //!     Match an integer in base 2 or base 16. The `_hex` parsers allow both
 //!     uppercase and lowercase digits `A`-`F`.
 //!
@@ -381,11 +383,11 @@ pub mod prelude {
     pub use crate::util::aoc_parse;
 
     pub use crate::parsers::{
-        alnum, alpha, any_char, bool, char_of, digit, digit_bin, digit_hex, i128, i128_bin,
-        i128_hex, i16, i16_bin, i16_hex, i32, i32_bin, i32_hex, i64, i64_bin, i64_hex, i8, i8_bin,
-        i8_hex, isize, isize_bin, isize_hex, lower, u128, u128_bin, u128_hex, u16, u16_bin,
-        u16_hex, u32, u32_bin, u32_hex, u64, u64_bin, u64_hex, u8, u8_bin, u8_hex, upper, usize,
-        usize_bin, usize_hex,
+        alnum, alpha, any_char, big_int, big_int_bin, big_int_hex, big_uint, big_uint_bin,
+        big_uint_hex, bool, char_of, digit, digit_bin, digit_hex, i128, i128_bin, i128_hex, i16,
+        i16_bin, i16_hex, i32, i32_bin, i32_hex, i64, i64_bin, i64_hex, i8, i8_bin, i8_hex, isize,
+        isize_bin, isize_hex, lower, u128, u128_bin, u128_hex, u16, u16_bin, u16_hex, u32, u32_bin,
+        u32_hex, u64, u64_bin, u64_hex, u8, u8_bin, u8_hex, upper, usize, usize_bin, usize_hex,
     };
 
     pub use crate::parsers::{line, lines, repeat_sep, section, sections};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -50,6 +50,7 @@
 
 pub use crate::parsers::{
     alt, empty, lines, map, opt, pair, plus, sequence, single_value, star,
+    RuleSetBuilder,
 };
 
 /// Macro that creates a parser for a given pattern.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -48,7 +48,9 @@
 //! //      ^ERROR: call expression requires function
 //! ```
 
-pub use crate::parsers::{alt, empty, lines, map, opt, pair, plus, sequence, single_value, star};
+pub use crate::parsers::{
+    alt, empty, lines, map, opt, pair, plus, sequence, single_value, star,
+};
 
 /// Macro that creates a parser for a given pattern.
 ///

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,6 +37,12 @@
 //!
 //! ```compile_fail
 //! # use aoc_parse::{parser, prelude::*};
+//! let p = parser!(rule value: i64 = i64;);
+//! //      ^ERROR: missing final pattern
+//! ```
+//!
+//! ```compile_fail
+//! # use aoc_parse::{parser, prelude::*};
 //! let p = parser! {
 //!     rule expr = {
 //!         t:term => t,
@@ -498,6 +504,10 @@ macro_rules! aoc_parse_helper {
                 [ $( $rule )* $other ]
                 [ $( $out )* ]
         )
+    };
+
+    (@split_rules [] [] [ $( $out:tt )* ]) => {
+        ::core::compile_error!("missing final pattern (at the end of a rule set, specify which rule is the starting point for parsing)")
     };
 
     // aoc_parse_helper!(@...) - This is an internal error, shouldn't happen in the wild.

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -8,6 +8,7 @@ mod map;
 mod primitive;
 mod regex;
 mod repeat;
+mod rule_set;
 mod sequence;
 mod string;
 
@@ -25,6 +26,7 @@ pub use primitive::{
     BasicParseIter,
 };
 pub use repeat::{plus, repeat, repeat_sep, star, RepeatParser};
+pub use rule_set::{RuleSetBuilder, RuleParser, RuleSetParser};
 pub use sequence::{pair, sequence, SequenceParser};
 pub use string::StringParser;
 

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -1,4 +1,5 @@
 mod chars;
+mod dynamic;
 mod either;
 mod empty;
 mod exact;

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -26,7 +26,7 @@ pub use primitive::{
     BasicParseIter,
 };
 pub use repeat::{plus, repeat, repeat_sep, star, RepeatParser};
-pub use rule_set::{RuleSetBuilder, RuleParser, RuleSetParser};
+pub use rule_set::{RuleParser, RuleSetBuilder, RuleSetParser};
 pub use sequence::{pair, sequence, SequenceParser};
 pub use string::StringParser;
 

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -17,10 +17,11 @@ pub use empty::{empty, EmptyParser};
 pub use lines::{line, lines, section, sections, LineParser, SectionParser};
 pub use map::{map, single_value, skip, MapParser};
 pub use primitive::{
-    bool, i128, i128_bin, i128_hex, i16, i16_bin, i16_hex, i32, i32_bin, i32_hex, i64, i64_bin,
-    i64_hex, i8, i8_bin, i8_hex, isize, isize_bin, isize_hex, u128, u128_bin, u128_hex, u16,
-    u16_bin, u16_hex, u32, u32_bin, u32_hex, u64, u64_bin, u64_hex, u8, u8_bin, u8_hex, usize,
-    usize_bin, usize_hex, BasicParseIter,
+    big_int, big_int_bin, big_int_hex, big_uint, big_uint_bin, big_uint_hex, bool, i128, i128_bin,
+    i128_hex, i16, i16_bin, i16_hex, i32, i32_bin, i32_hex, i64, i64_bin, i64_hex, i8, i8_bin,
+    i8_hex, isize, isize_bin, isize_hex, u128, u128_bin, u128_hex, u16, u16_bin, u16_hex, u32,
+    u32_bin, u32_hex, u64, u64_bin, u64_hex, u8, u8_bin, u8_hex, usize, usize_bin, usize_hex,
+    BasicParseIter,
 };
 pub use repeat::{plus, repeat, repeat_sep, star, RepeatParser};
 pub use sequence::{pair, sequence, SequenceParser};

--- a/src/parsers/dynamic.rs
+++ b/src/parsers/dynamic.rs
@@ -1,0 +1,123 @@
+//! A type that behaves like `Box<dyn Parser<Output=T>>` (even though `Parser`
+//! itself has other associated types that would make this impossible).
+
+use crate::{
+    parsers::{map::SingleValueParser, single_value},
+    ParseIter, Parser, Reported, Result,
+};
+
+trait MyDynParserTrait<Out> {
+    fn parse_iter<'parse>(
+        &'parse self,
+        context: &mut crate::ParseContext<'parse>,
+        start: usize,
+    ) -> Result<DynParseIter<'parse, Out>, Reported>;
+}
+
+/// Any parser that produces a value of type Out.
+///
+/// Unlike most parsers, this is not necessarily `Copy` or `Clone`.
+pub struct DynParser<'parser, Out> {
+    inner: Box<dyn MyDynParserTrait<Out> + 'parser>,
+}
+
+pub struct DynParseIter<'parse, T> {
+    inner: Box<dyn ParseIter<'parse, RawOutput = (T,)> + 'parse>,
+}
+
+impl<P> MyDynParserTrait<P::Output> for SingleValueParser<P>
+where
+    P: Parser,
+{
+    fn parse_iter<'parse>(
+        &'parse self,
+        context: &mut crate::ParseContext<'parse>,
+        start: usize,
+    ) -> Result<DynParseIter<'parse, P::Output>, Reported> {
+        let iter = <SingleValueParser<P> as Parser>::parse_iter(self, context, start)?;
+        Ok(DynParseIter {
+            inner: Box::new(iter),
+        })
+    }
+}
+
+impl<'parser, Out> DynParser<'parser, Out> {
+    /// Wrap any parser in a `DynParser<'parser, T>`, parameterized only on the
+    /// output type (not Iter or RawOutput).
+    ///
+    /// This isn't exposed as a documented API for a couple of reasons.
+    ///
+    /// -   I'm not sure we can't do better; this type doesn't pass through `Copy`,
+    ///     `Clone`, `Send`, or `Sync`. It also hardcodes `Box`, so patterns like
+    ///     `Arc<dyn ...>` won't work. (Of course for the Advent of Code use case
+    ///     this doesn't matter too much.)
+    ///
+    /// -   This is meant as an implemention detail of rule-sets, a `parser!`
+    ///     feature. There are several other similar functions, and so far all of
+    ///     them are undocumented.
+    ///
+    #[doc(hidden)]
+    #[allow(dead_code)]
+    pub(crate) fn new<P>(parser: P) -> Self
+    where
+        P: Parser<Output = Out> + 'parser,
+    {
+        DynParser {
+            inner: Box::new(single_value(parser)),
+        }
+    }
+}
+
+impl<'parser, Out> Parser for DynParser<'parser, Out> {
+    type Output = Out;
+
+    type RawOutput = (Out,);
+
+    type Iter<'parse> = DynParseIter<'parse, Out>
+    where
+        Self: 'parse;
+
+    fn parse_iter<'parse>(
+        &'parse self,
+        context: &mut crate::ParseContext<'parse>,
+        start: usize,
+    ) -> Result<Self::Iter<'parse>, Reported> {
+        let iter = self.inner.parse_iter(context, start)?;
+        Ok(iter)
+    }
+}
+
+impl<'parse, T> ParseIter<'parse> for DynParseIter<'parse, T> {
+    type RawOutput = (T,);
+
+    fn match_end(&self) -> usize {
+        self.inner.match_end()
+    }
+
+    fn backtrack(&mut self, context: &mut crate::ParseContext<'parse>) -> Result<(), Reported> {
+        self.inner.backtrack(context)
+    }
+
+    fn convert(&self) -> Self::RawOutput {
+        self.inner.convert()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parsers::{i32, map, u64};
+    use crate::testing::*;
+
+    #[test]
+    fn test_dynamic() {
+        let mut p = DynParser::new(u64);
+        assert_parse_eq(p, "1141413", 1141413);
+
+        // We assign another parser, with a completely different underlying
+        // implementation type, to the same variable, because the wrapper has
+        // the same type.
+        p = DynParser::new(map(i32, |x| x as u64));
+        assert_parse_eq(p, "-1", 0xffff_ffff_ffff_ffff_u64);
+    }
+}

--- a/src/parsers/rule_set.rs
+++ b/src/parsers/rule_set.rs
@@ -1,0 +1,183 @@
+use std::{any::Any, pin::Pin, marker::PhantomData};
+
+use crate::{Parser, parsers::dynamic::{DynParseIter, DynParser}, Reported, ParseContext};
+
+/// Builder for constructing a parser based on a rule set.
+///
+/// Builder methods must be called in a strict order:
+///
+/// -   First `new()` to create the builder.
+/// -   Then `.new_rule()` 0 or more times to create the rules.
+/// -   Then `.assign_parser_for_rule()` the same number of times, in the same order,
+///     to assign the actual parsers implementing each rule.
+/// -   Lastly `.build()` to build the entry point to the rule set.
+pub struct RuleSetBuilder{
+    id: Pin<Box<u8>>,
+    capacity: usize,
+    rule_parsers: Vec<Box<dyn Any>>,
+}
+
+#[derive(Debug)]
+pub struct RuleParser<T> {
+    rule_set_id: usize,
+    index: usize,
+    phantom: PhantomData<fn () -> T>,
+}
+
+pub struct RuleSetParser<T> {
+    id: Pin<Box<u8>>,
+    rule_parsers: Vec<Box<dyn Any>>,
+    entry_parser: DynParser<'static, T>,
+}
+
+impl RuleSetBuilder {
+    /// Create a builder to build a new parser based on a rule set.
+    ///
+    /// This is used by the `parser!` macro to implement `rule`.
+    #[doc(hidden)]
+    pub fn new() -> Self {
+        RuleSetBuilder {
+            id: Box::pin(0),
+            capacity: 0,
+            rule_parsers: vec![],
+        }
+    }
+
+    /// Create a `Copy` parser as a placeholder for a rule in a rule set.
+    ///
+    /// This is used by the `parser!` macro to implement `rule`.
+    #[doc(hidden)]
+    pub fn new_rule<T>(&mut self) -> RuleParser<T> {
+        let index = self.capacity;
+        self.capacity += 1;
+        RuleParser {
+            rule_set_id: self.id(),
+            index,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Set the parser to be used when the given parser `nt` is invoked.
+    ///
+    /// This is used by the `parser!` macro to implement `rule`.
+    #[doc(hidden)]
+    pub fn assign_parser_for_rule<T, P>(&mut self, nt: &RuleParser<T>, parser: P)
+    where
+        T: 'static,
+        P: Parser<Output = T> + 'static,
+    {
+        assert_eq!(nt.rule_set_id, self.id());
+        assert_eq!(nt.index, self.rule_parsers.len());
+
+        // We are double-boxing the parsers at the moment. Look away
+        self.rule_parsers.push(Box::new(DynParser::new(parser)));
+    }
+
+    /// Build the rule-set-based parser.
+    ///
+    /// This is used by the `parser!` macro to implement `rule`.
+    #[doc(hidden)]
+    pub fn build<P>(self, parser: P) -> RuleSetParser<P::Output>
+    where
+        P: Parser + 'static,
+    {
+        RuleSetParser {
+            id: self.id,
+            rule_parsers: self.rule_parsers,
+            entry_parser: DynParser::new(parser),
+        }
+    }
+
+    fn id(&self) -> usize {
+        &self.id as &u8 as *const u8 as usize
+    }
+}
+
+// Explicit impl because `#[derive(Clone)]` fails to do the right thing in this
+// case.
+impl<T> Clone for RuleParser<T> {
+    fn clone(&self) -> Self {
+        RuleParser {
+            rule_set_id: self.rule_set_id,
+            index: self.index,
+            phantom: self.phantom
+        }
+    }
+}
+
+impl<T> Copy for RuleParser<T> {}
+
+impl<T> Parser for RuleParser<T>
+where
+    T: 'static,
+{
+    type Output = T;
+    type RawOutput = (T,);
+    type Iter<'parse> = DynParseIter<'parse, T> where T: 'parse;
+
+    fn parse_iter<'parse>(
+        &'parse self,
+        context: &mut ParseContext<'parse>,
+        start: usize,
+    ) -> Result<Self::Iter<'parse>, Reported> {
+        let parser_as_any: &'parse dyn Any = context.fetch_parser_for_rule(self.rule_set_id, self.index);
+        let parser = parser_as_any.downcast_ref::<DynParser<T>>().expect("internal error: downcast failed");
+        parser.parse_iter(context, start)
+    }
+}
+
+impl<T> RuleSetParser<T> {
+    fn id(&self) -> usize {
+        &self.id as &u8 as *const u8 as usize
+    }
+}
+
+impl<T> Parser for RuleSetParser<T> {
+    type Output = T;
+    type RawOutput = (T,);
+    type Iter<'parse> = DynParseIter<'parse, T> where T: 'parse;
+
+    fn parse_iter<'parse>(
+        &'parse self,
+        context: &mut ParseContext<'parse>,
+        start: usize,
+    ) -> Result<Self::Iter<'parse>, Reported> {
+        context.register_rule_set(self.id(), &self.rule_parsers);
+        self.entry_parser.parse_iter(context, start)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::*;
+    use crate::parsers::{repeat_sep, pair, alt, map, u32};
+
+    #[test]
+    fn test_rule_set() {
+        #[derive(Debug, PartialEq)]
+        enum Value {
+            Int(u32),
+            List(Vec<Value>),
+        }
+
+        let value_parser = {
+            let mut builder = RuleSetBuilder::new();
+            let value: RuleParser<Value> = builder.new_rule();
+            let values: RuleParser<Vec<Value>> = builder.new_rule();
+
+            builder.assign_parser_for_rule(&value, alt(
+                map(u32, Value::Int),
+                alt(
+                    map("[]", |()| Value::List(vec![])),
+                    map(pair("[", pair(values, "]")), |(_, (vs, _))| Value::List(vs)),
+                ),
+            ));
+            builder.assign_parser_for_rule(&values, repeat_sep(value, ","));
+            builder.build(value)
+        };
+
+        assert_parse_eq(&value_parser, "92183", Value::Int(92183));
+        assert_parse_eq(&value_parser, "[3,[7,88]]", Value::List(vec![Value::Int(3), Value::List(vec![Value::Int(7), Value::Int(88)])]));
+    }
+}

--- a/tests/test_2022.rs
+++ b/tests/test_2022.rs
@@ -471,6 +471,56 @@ Monkey 3:
 }
 
 #[test]
+fn day13() {
+    #[derive(Debug, PartialEq)]
+    enum Value {
+        Int(u32),
+        List(Vec<Value>),
+    }
+
+    let value = &parser!(
+        rule value: Value = {
+            n:u32 => Value::Int(n),
+            "[]" => Value::List(vec![]),
+            "[" vs:values "]" => Value::List(vs),
+        };
+        rule values: Vec<Value> = repeat_sep(value, ",");
+        value
+    );
+
+    let p = parser!(sections(line(value) line(value)));
+
+    let example = "\
+[1,1,3,1,1]
+[1,1,5,1,1]
+
+[[1],[2,3,4]]
+[[1],4]
+
+[9]
+[[8,7,6]]
+";
+
+    let i = Value::Int;
+
+    fn v(iter: impl IntoIterator<Item = Value>) -> Value {
+        Value::List(iter.into_iter().collect())
+    }
+
+    assert_eq!(
+        p.parse(example).unwrap(),
+        vec![
+            (
+                v([i(1), i(1), i(3), i(1), i(1)]),
+                v([i(1), i(1), i(5), i(1), i(1)]),
+            ),
+            (v([v([i(1)]), v([i(2), i(3), i(4)])]), v([v([i(1)]), i(4)])),
+            (v([i(9)]), v([v([i(8), i(7), i(6)])])),
+        ],
+    );
+}
+
+#[test]
 fn day15() {
     let input = "\
 Sensor at x=2, y=18: closest beacon is at x=-2, y=15

--- a/tests/test_json_parser.rs
+++ b/tests/test_json_parser.rs
@@ -1,0 +1,148 @@
+#![recursion_limit = "1024"]
+
+use std::fmt::Debug;
+
+use aoc_parse::{parser, prelude::*};
+
+#[track_caller]
+fn assert_parse_eq<P, E>(parser: P, s: &str, expected: E)
+where
+    P: Parser,
+    P::Output: PartialEq<E> + Debug,
+    E: Debug,
+{
+    match parser.parse(s) {
+        Err(err) => panic!("parse failed: {}", err),
+        Ok(val) => assert_eq!(val, expected),
+    }
+}
+
+#[test]
+fn test_rule_set_json() {
+    use serde_json::{Value, Number, Map};
+
+    let json = parser!(
+        // https://www.rfc-editor.org/rfc/rfc8259#page-5
+        rule ws: () = { ' ', '\t', '\r', '\n' }* => ();
+        rule value: Value = {
+            "null" => Value::Null,
+            "false" => Value::Bool(false),
+            "true" => Value::Bool(true),
+            o:object => Value::Object(o),
+            a:array => Value::Array(a),
+            n:number => Value::Number(n),
+            s:json_string => Value::String(s),
+        };
+        rule json_string: String =
+            '"'
+            s:string(char_of( // approximation: any ascii character but " and backslash
+                " !#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+            )*)
+            '"'
+            => s;
+        rule object: Map<String, Value> =
+            ws '{' ws
+            members:repeat_sep(member, ws ',' ws)
+            ws '}' ws
+            => { eprintln!("NUMBER OF MEMBERS: {}", members.len()); members.into_iter().collect()};
+        rule member: (String, Value) =
+            k:json_string ws ':' ws v:value => (k, v);
+        rule array: Vec<Value> =
+            ws '[' ws
+            elems:repeat_sep(value, ws ',' ws)
+            ws ']' ws
+            => elems;
+        rule number: Number =
+            s:string('-'? int frac? exp?) => s.parse::<Number>().unwrap();
+        rule int: () = {'0' => (), char_of("123456789") digit* => ()};
+        rule frac: () = '.' digit+ => ();
+        rule exp: () = {'e', 'E'} i64 => ();
+
+        value
+    );
+
+    // Example from the standard (section 13).
+    assert_parse_eq(
+        &json,
+        r#"
+            {
+              "Image": {
+                  "Width":  800,
+                  "Height": 600,
+                  "Title":  "View from 15th Floor",
+                  "Thumbnail": {
+                      "Url":    "http://www.example.com/image/481989943",
+                      "Height": 125,
+                      "Width":  100
+                  },
+                  "Animated" : false,
+                  "IDs": [116, 943, 234, 38793]
+                }
+            }
+          "#,
+        serde_json::json!(
+            {
+                "Image": {
+                    "Width":  800,
+                    "Height": 600,
+                    "Title":  "View from 15th Floor",
+                    "Thumbnail": {
+                        "Url":    "http://www.example.com/image/481989943",
+                        "Height": 125,
+                        "Width":  100
+                    },
+                    "Animated" : false,
+                    "IDs": [116, 943, 234, 38793]
+                }
+            }
+        )
+    );
+
+    assert_parse_eq(
+        &json,
+        r#"  [
+        {
+           "precision": "zip",
+           "Latitude":  37.7668,
+           "Longitude": -122.3959,
+           "Address":   "",
+           "City":      "SAN FRANCISCO",
+           "State":     "CA",
+           "Zip":       "94107",
+           "Country":   "US"
+        },
+        {
+           "precision": "zip",
+           "Latitude":  37.371991,
+           "Longitude": -122.026020,
+           "Address":   "",
+           "City":      "SUNNYVALE",
+           "State":     "CA",
+           "Zip":       "94085",
+           "Country":   "US"
+        }
+      ]"#,
+        serde_json::json!([
+            {
+                "precision": "zip",
+                "Latitude":  37.7668,
+                "Longitude": -122.3959,
+                "Address":   "",
+                "City":      "SAN FRANCISCO",
+                "State":     "CA",
+                "Zip":       "94107",
+                "Country":   "US"
+            },
+            {
+                "precision": "zip",
+                "Latitude":  37.371991,
+                "Longitude": -122.026020,
+                "Address":   "",
+                "City":      "SUNNYVALE",
+                "State":     "CA",
+                "Zip":       "94085",
+                "Country":   "US"
+            }
+        ])
+    );
+}

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -290,3 +290,25 @@ f0w88yhf
         ),
     );
 }
+
+#[test]
+fn test_rule_set() {
+    let calc = parser!(
+        rule expr: i64 =
+            t:term a:addn* => t + a.into_iter().sum::<i64>();
+        rule addn: i64 = {
+            '+' t:term => t,
+            '-' t:term => -t,
+        };
+        rule term: i64 =
+            p:prim ops:('*' prim)* => p * ops.into_iter().product::<i64>();
+        rule prim: i64 = {
+            n:i64 => n,
+            '(' e:expr ')' => e,
+        };
+        expr
+    );
+
+    assert_parse_eq(&calc, "2+2", 4);
+    assert_parse_eq(&calc, "2+(3*(4+5+2))", 35);
+}


### PR DESCRIPTION
Support syntax like `parser!(rule NAME: TYPE = PARSER; ...)`. See #2 or the code for examples. Still needs documentation.

Closes #2.