### PR TITLE
`repeat_n` and friends

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,21 @@ any number of times, separated by the *separator*. This converts only the bits t
 *pattern* to Rust values, producing a `Vec`. Any parts of the string matched by *separator* are
 not converted.
 
+<code>repeat_n(<var>pattern</var>, <var>n</var>)</code>,
+<code>repeat_min(<var>pattern</var>, <var>min</var>)</code>,
+<code>repeat_max(<var>pattern</var>, <var>max</var>)</code>,
+<code>repeat_min_max(<var>pattern</var>, <var>min</var>, <var>max</var>)</code> -
+Match the given *pattern* repeated the specified number of times, with no separator, producing
+a `Vec`.
+
+<code>repeat_sep_n(<var>pattern</var>, <var>sep</var>, <var>n</var>)</code>,
+<code>repeat_sep_min(<var>pattern</var>, <var>sep</var>, <var>min</var>)</code>,
+<code>repeat_sep_max(<var>pattern</var>, <var>sep</var>, <var>max</var>)</code>,
+<code>repeat_sep_min_max(<var>pattern</var>, <var>sep</var>, <var>min</var>, <var>max</var>)</code> -
+Match the given *pattern* repeated the specified number of times, separated by the *separator*.
+Like `repeat_sep`, these functions convert the text matching *pattern* and discard the text
+matched by *separator*. Produces a `Vec`.
+
 ### Matching single characters
 
 `alpha`, `alnum`, `upper`, `lower` - Match single characters of various categories. (These use
@@ -206,7 +221,7 @@ on. All the patterns must produce the same type of Rust value.
 This is sort of like a Rust `match` expression.
 
 For example, `parser!({"<" => -1, ">" => 1})` either matches `<`, returning the value `-1`, or
-matches `>`, returing `1`.
+matches `>`, returning `1`.
 
 Alternatives are handy when you want to convert the input into an enum. For example, my puzzle
 input for December 23, 2015 was a list of instructions that looked (in part) like this:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -453,15 +453,5 @@ pub mod prelude {
         u8, u8_bin, u8_hex, upper, usize, usize_bin, usize_hex, vec_deque,
     };
 
-    pub use crate::parsers::{line, lines, repeat_sep, section, sections};
-
-    /// Parse using `parser`, but instead of converting the matched text to a
-    /// Rust value, simply return it as a `String`.
-    ///
-    /// By default, `parser!(alpha+)` returns a `Vec<char>`, and sometimes that
-    /// is handy in AoC, but often it's better to have it return a `String`.
-    /// That can be done with `parser!(string(alpha+))`.
-    pub fn string<P: Parser>(parser: P) -> crate::parsers::StringParser<P> {
-        crate::parsers::StringParser { parser }
-    }
+    pub use crate::parsers::{line, lines, repeat_sep, section, sections, string};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,21 @@
 //! *pattern* to Rust values, producing a `Vec`. Any parts of the string matched by *separator* are
 //! not converted.
 //!
+//! <code>repeat_n(<var>pattern</var>, <var>n</var>)</code>,
+//! <code>repeat_min(<var>pattern</var>, <var>min</var>)</code>,
+//! <code>repeat_max(<var>pattern</var>, <var>max</var>)</code>,
+//! <code>repeat_min_max(<var>pattern</var>, <var>min</var>, <var>max</var>)</code> -
+//! Match the given *pattern* repeated the specified number of times, with no separator, producing
+//! a `Vec`.
+//!
+//! <code>repeat_sep_n(<var>pattern</var>, <var>sep</var>, <var>n</var>)</code>,
+//! <code>repeat_sep_min(<var>pattern</var>, <var>sep</var>, <var>min</var>)</code>,
+//! <code>repeat_sep_max(<var>pattern</var>, <var>sep</var>, <var>max</var>)</code>,
+//! <code>repeat_sep_min_max(<var>pattern</var>, <var>sep</var>, <var>min</var>, <var>max</var>)</code> -
+//! Match the given *pattern* repeated the specified number of times, separated by the *separator*.
+//! Like `repeat_sep`, these functions convert the text matching *pattern* and discard the text
+//! matched by *separator*. Produces a `Vec`.
+//!
 //! ## Matching single characters
 //!
 //! `alpha`, `alnum`, `upper`, `lower` - Match single characters of various categories. (These use
@@ -213,7 +228,7 @@
 //! This is sort of like a Rust `match` expression.
 //!
 //! For example, `parser!({"<" => -1, ">" => 1})` either matches `<`, returning the value `-1`, or
-//! matches `>`, returing `1`.
+//! matches `>`, returning `1`.
 //!
 //! Alternatives are handy when you want to convert the input into an enum. For example, my puzzle
 //! input for December 23, 2015 was a list of instructions that looked (in part) like this:
@@ -453,5 +468,8 @@ pub mod prelude {
         u8, u8_bin, u8_hex, upper, usize, usize_bin, usize_hex, vec_deque,
     };
 
-    pub use crate::parsers::{line, lines, repeat_sep, section, sections, string};
+    pub use crate::parsers::{
+        line, lines, repeat_max, repeat_min, repeat_min_max, repeat_n, repeat_sep, repeat_sep_max,
+        repeat_sep_min, repeat_sep_min_max, repeat_sep_n, section, sections, string,
+    };
 }

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -27,7 +27,10 @@ pub use primitive::{
     u32, u32_bin, u32_hex, u64, u64_bin, u64_hex, u8, u8_bin, u8_hex, usize, usize_bin, usize_hex,
     BasicParseIter,
 };
-pub use repeat::{plus, repeat, repeat_sep, star, RepeatParser};
+pub use repeat::{
+    plus, repeat_max, repeat_min, repeat_min_max, repeat_n, repeat_sep, repeat_sep_max,
+    repeat_sep_min, repeat_sep_min_max, repeat_sep_n, star, RepeatParser,
+};
 pub use rule_set::{RuleParser, RuleSetBuilder, RuleSetParser};
 pub use sequence::{pair, sequence, SequenceParser};
 pub use string::{string, StringParser};

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -30,7 +30,7 @@ pub use primitive::{
 pub use repeat::{plus, repeat, repeat_sep, star, RepeatParser};
 pub use rule_set::{RuleParser, RuleSetBuilder, RuleSetParser};
 pub use sequence::{pair, sequence, SequenceParser};
-pub use string::StringParser;
+pub use string::{string, StringParser};
 
 // --- Wrappers
 

--- a/src/parsers/repeat.rs
+++ b/src/parsers/repeat.rs
@@ -255,6 +255,102 @@ pub fn repeat_sep<Pattern, Sep>(pattern: Pattern, sep: Sep) -> RepeatParser<Patt
     repeat(pattern, sep, 0, None, false)
 }
 
+/// <code>repeat_n(<var>pattern</var>, <var>n</var>)</code> matches the given *pattern* exactly *n*
+/// times, with no separator.
+///
+/// Each match is converted to a Rust value, producing a `Vec`.
+pub fn repeat_n<Pattern>(pattern: Pattern, n: usize) -> RepeatParser<Pattern, EmptyParser> {
+    repeat(pattern, empty(), n, Some(n), false)
+}
+
+/// <code>repeat_min(<var>pattern</var>, <var>min</var>)</code> matches the given *pattern*
+/// repeated *min* or more times, with no separator.
+///
+/// Each match is converted to a Rust value, producing a `Vec`.
+pub fn repeat_min<Pattern>(pattern: Pattern, min: usize) -> RepeatParser<Pattern, EmptyParser> {
+    repeat(pattern, empty(), min, None, false)
+}
+
+/// <code>repeat_max(<var>pattern</var>, <var>max</var>)</code> matches the given *pattern*
+/// repeated up to *max* times, with no separator.
+///
+/// Each match is converted to a Rust value, producing a `Vec`.
+pub fn repeat_max<Pattern>(pattern: Pattern, max: usize) -> RepeatParser<Pattern, EmptyParser> {
+    repeat(pattern, empty(), 0, Some(max), false)
+}
+
+/// <code>repeat_min_max(<var>pattern</var>, <var>min</var>, <var>max</var>)</code> matches the
+/// given *pattern* repeated at least *min* times, and up to *max* times, with no separator.
+///
+/// Each match is converted to a Rust value, producing a `Vec`.
+///
+/// # Panics
+///
+/// If `min > max`.
+pub fn repeat_min_max<Pattern>(
+    pattern: Pattern,
+    min: usize,
+    max: usize,
+) -> RepeatParser<Pattern, EmptyParser> {
+    assert!(min <= max);
+    repeat(pattern, empty(), min, Some(max), false)
+}
+
+/// <code>repeat_sep_n(<var>pattern</var>, <var>sep</var>, <var>n</var>)</code> matches the
+/// given *pattern* repeated exactly *n* times, separated by the *separator*.
+///
+/// The bits that match *pattern* are converted to Rust values, producing a `Vec`.
+/// Parts of the string matched by *separator* are not converted.
+pub fn repeat_sep_n<Pattern, Sep>(pattern: Pattern, sep: Sep, n: usize) -> RepeatParser<Pattern, Sep> {
+    repeat(pattern, sep, n, Some(n), false)
+}
+
+/// <code>repeat_sep_min(<var>pattern</var>, <var>sep</var>, <var>min</var>)</code> matches the
+/// given *pattern* repeated at least *min* times, separated by the *separator*.
+///
+/// The bits that match *pattern* are converted to Rust values, producing a `Vec`.
+/// Parts of the string matched by *separator* are not converted.
+pub fn repeat_sep_min<Pattern, Sep>(
+    pattern: Pattern,
+    sep: Sep,
+    min: usize,
+) -> RepeatParser<Pattern, Sep> {
+    repeat(pattern, sep, min, None, false)
+}
+
+/// <code>repeat_sep_max(<var>pattern</var>, <var>sep</var>, <var>max</var>)</code> matches the
+/// given *pattern* repeated up to *max* times, separated by the *separator*.
+///
+/// The bits that match *pattern* are converted to Rust values, producing a `Vec`.
+/// Parts of the string matched by *separator* are not converted.
+pub fn repeat_sep_max<Pattern, Sep>(
+    pattern: Pattern,
+    sep: Sep,
+    max: usize,
+) -> RepeatParser<Pattern, Sep> {
+    repeat(pattern, sep, 0, Some(max), false)
+}
+
+/// <code>repeat_sep_min_max(<var>pattern</var>, <var>sep</var>, <var>min</var>,
+/// <var>max</var>)</code> matches the given *pattern* repeated at least *min* times, and up to
+/// *max* times, separated by the *separator*.
+///
+/// The bits that match *pattern* are converted to Rust values, producing a `Vec`.
+/// Parts of the string matched by *separator* are not converted.
+///
+/// # Panics
+///
+/// If `min > max`.
+pub fn repeat_sep_min_max<Pattern, Sep>(
+    pattern: Pattern,
+    sep: Sep,
+    min: usize,
+    max: usize,
+) -> RepeatParser<Pattern, Sep> {
+    assert!(min <= max);
+    repeat(pattern, sep, min, Some(max), false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/parsers/string.rs
+++ b/src/parsers/string.rs
@@ -60,3 +60,13 @@ where
         (value,)
     }
 }
+
+/// Parse using `parser`, but instead of converting the matched text to a
+/// Rust value, simply return it as a `String`.
+///
+/// By default, `parser!(alpha+)` returns a `Vec<char>`, and sometimes that
+/// is handy in AoC, but often it's better to have it return a `String`.
+/// That can be done with `parser!(string(alpha+))`.
+pub fn string<P: Parser>(parser: P) -> StringParser<P> {
+    crate::parsers::StringParser { parser }
+}

--- a/tests/test_2017.rs
+++ b/tests/test_2017.rs
@@ -1,0 +1,57 @@
+use std::fmt::Debug;
+
+use aoc_parse::{parser, prelude::*};
+
+#[test]
+fn day21() {
+    let input = "\
+../.# => ##./#../...
+.#./..#/### => #..#/..../..../#..#
+";
+
+    type Grid = Vec<Vec<bool>>;
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum EnhancementRule {
+        ByTwos(Grid, Grid),
+        ByThrees(Grid, Grid),
+    }
+
+    let p = parser!(
+        rule bit: bool = { '#' => true, '.' => false };
+        rule g2: Grid = repeat_sep_n(repeat_n(bit, 2), '/', 2);
+        rule g3: Grid = repeat_sep_n(repeat_n(bit, 3), '/', 3);
+        rule g4: Grid = repeat_sep_n(repeat_n(bit, 4), '/', 4);
+        lines({
+            input:g2 " => " output:g3 => EnhancementRule::ByTwos(input, output),
+            input:g3 " => " output:g4 => EnhancementRule::ByThrees(input, output),
+        })
+    );
+
+    assert_eq!(
+        p.parse(input).unwrap(),
+        vec![
+            EnhancementRule::ByTwos(
+                vec![vec![false, false], vec![false, true]],
+                vec![
+                    vec![true, true, false],
+                    vec![true, false, false],
+                    vec![false, false, false],
+                ]
+            ),
+            EnhancementRule::ByThrees(
+                vec![
+                    vec![false, true, false],
+                    vec![false, false, true],
+                    vec![true, true, true],
+                ],
+                vec![
+                    vec![true, false, false, true],
+                    vec![false, false, false, false],
+                    vec![false, false, false, false],
+                    vec![true, false, false, true],
+                ]
+            )
+        ],
+    );
+}


### PR DESCRIPTION
I'm not sure all of these are really needed, but regular expressions have all of them.

Something a little weird about this: the numeric arguments must be either literals like `2` or `3`, or an identifier like `n` or `GRID_SIZE`. The macro would treat anything else as a parser-expression, not a Rust expression. Of course in practice people will naturally pass number literals... but the error message when someone writes `parser!(repeat_n("A", n + 1))` will probably be pretty confusing.

Closes #7.